### PR TITLE
Added @export tag to functions mentioned in the tutorial

### DIFF
--- a/R/MakeLongMockSample.R
+++ b/R/MakeLongMockSample.R
@@ -1,3 +1,4 @@
+##' @export
 MakeLongMockSample <- function(CNVDistance=1000, Type=c(0,1,2,3,4), Mean=c(-0.9, -0.8, -0.7, -0.6, -0.5, -0.4, -0.3, -0.2, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9), Size=c(100, 200, 300, 400, 500, 600, 700, 800, 900, 1000))
 {
 	library(RColorBrewer)

--- a/R/MockData.R
+++ b/R/MockData.R
@@ -1,3 +1,4 @@
+##' @export
 MockData <- function(N=1, Wave1=FALSE, Type="Blood", Cores=1) # Type: Blood or PKU (Perfect or noise)
 {
 	# Use Wave1 PFB ? Wave1PFB comes with the package.


### PR DESCRIPTION
The @export tag defines which functions are available to the user - I.e. functions which are only called by other functions can be hidden by not adding the @export flag since they will not be exported to the NAMESPACE file when the package is build. These two are mentioned in the tutorial so they should be exported. Otherwise I cannot see them if i build the package directly from the library using devtools:

library(devtools)
document("path/to/iPsychCNV")
install("path/to/iPsychCNV")
