### PR TITLE
Fixed stackplot issues and swapt spots of BAF and Intensity to fit with plotCNVs

### DIFF
--- a/R/NormalizeData.R
+++ b/R/NormalizeData.R
@@ -8,7 +8,7 @@
 ##' @param Quantile: Logical, if quantile normalization should be applied or not, default = FALSE.
 ##' @param QSpline: Logical, if a cubic smoothing spline should be used to normalize the data, default = FALSE.
 ##' @param Sd: Numeric, LRR standard deviation for the quantile normarlization, default = 0.18.
-##' @parem ReCenter: Re-center LRR mean to be zero.
+##' @param ReCenter: Re-center LRR mean to be zero.
 ##' @return LRR normalized.
 ##' @author Marcelo Bertalan, Louise K. Hoeffding. 
 ##' @source \url{http://biopsych.dk/iPsychCNV}

--- a/R/StackPlot.R
+++ b/R/StackPlot.R
@@ -12,7 +12,7 @@
 ##' @param OutFolder: Path for saving outputfiles. Default is current folder
 ##' @param Files: Full path for each sample. You can get it using the command: Files <- list.files(path=PathRawData, pattern=Pattern, full.names=TRUE, recursive=recursive). Then use Files=Files.
 ##' @param Pattern: File pattern in the raw data, default = "*".
-##' @param Recursive: Logical, Unknown, default = TRUE.
+##' @param Recursive: Logical, Should files matching patterns in subfolders be included, default = FALSE.
 ##' @return A png plot of the specified loci.
 ##' @author Johan Hilge Thygesen, Ida Elken Sønderby, Louise K. Hoeffding.
 ##' @source \url{http://biopsych.dk/iPsychCNV}
@@ -22,7 +22,7 @@
 ##' cnvs <- iPsychCNV(PathRawData=".", Cores=1, Pattern="^MockSample*", Skip=0)
 ##' StackPlot(Pos="chr21:28338230-46844965", IDs=unique(cnvs$ID), PathRawData=".", CNVs=cnvs, Highlight = "chr21:36653812-39117308")
 
-StackPlot <- function(Pos, IDs, PathRawData, CNVs, Highlight = NULL, SNPList=NULL, key=NA, OutFolder=".", Files=NA, Pattern="",recursive=TRUE){
+StackPlot <- function(Pos, IDs, PathRawData, CNVs, Highlight = NULL, SNPList=NULL, key=NA, OutFolder=".", Files=NA, Pattern="",recursive=FALSE){
   suppressPackageStartupMessages(library(data.table))
   options(scipen=999) ## Disable scientific notation of positions
 
@@ -53,7 +53,7 @@ StackPlot <- function(Pos, IDs, PathRawData, CNVs, Highlight = NULL, SNPList=NUL
   box <- 1
   pr.page <- 5
   datestamp <- gsub(":",".",unlist(strsplit(as.character(Sys.time())," "))[2])
-  if (!is.na(CNVs$locus[1])) {
+  if (!is.null(CNVs$locus[1])) {
     Locus <- as.character(CNVs$locus[1])
     basename <- paste(Locus, "_", "chr",chr,"-",reg.start,"-",reg.stop, sep="")
     } else {
@@ -66,7 +66,7 @@ StackPlot <- function(Pos, IDs, PathRawData, CNVs, Highlight = NULL, SNPList=NUL
   page.count <- 1 # start with page 1
 
   # Define Files
-  if(is.na(Files))
+  if(is.na(Files[1]))
   {
     Files <- list.files(path=PathRawData, pattern=Pattern, full.names=TRUE, recursive=recursive)
   }
@@ -121,9 +121,11 @@ StackPlot <- function(Pos, IDs, PathRawData, CNVs, Highlight = NULL, SNPList=NUL
           }
 
           ## Plot Log R ratio and Intensity boxes
-          rect(reg.start, topY-box, reg.stop, topY, col="#ffe2e2", border= F)
-          rect(reg.start, topY-(2*box+(space/2)), reg.stop, topY-(box+(space/2)), col="#e5e2ff", border= F)
-          ## Draw --Highlight box
+          rect(reg.start, topY-(2*box+(space/2)), reg.stop, topY-(box+(space/2)), col="#ffe2e2", border= F)
+          rect(reg.start, topY-box, reg.stop, topY, col="#e5e2ff", border= F)
+          
+
+            ## Draw --Highlight box
           if(length(Highlight) > 0) {
             segments(high.start, topY-(2*box+(space/2)), high.start, topY, col="black",lwd=1.5) # Start
             segments(high.stop, topY-(2*box+(space/2)), high.stop, topY, col="black",lwd=1.5) # Stop
@@ -141,8 +143,8 @@ StackPlot <- function(Pos, IDs, PathRawData, CNVs, Highlight = NULL, SNPList=NUL
             }
           }
           ## Plot Log R ratio and Intensity points
-          points(id[,"Position"], id[,"B.Allele.Freq"] + (topY-2*box-(space/2)), pch=20, cex=0.5, col = "darkblue")
-          points(id[,"Position"], (id[,"Log.R.Ratio"]/2) + (topY-(0.5*box)), pch=20, cex=0.5, col = "darkred")
+          points(id[,"Position"], id[,"B.Allele.Freq"] + (topY-(1*box)), pch=20, cex=0.5, col = "darkblue")
+          points(id[,"Position"], (id[,"Log.R.Ratio"]/2) + (topY-1.5*box-(space/2)), pch=20, cex=0.5, col = "darkred")
           ## Draw center line in boxs (x0, y0, x1, y1)
           segments(reg.start, topY-(box/2), reg.stop, topY-(box/2), col="black")
           segments(reg.start, (topY-1.5*box-(space/2)), reg.stop, (topY-1.5*box-(space/2)), col="black")

--- a/man/NormalizeData.Rd
+++ b/man/NormalizeData.Rd
@@ -22,6 +22,8 @@ NormalizeData(Sample = Sample, ExpectedMean = 0, penalty = 60,
 \item{QSpline:}{Logical, if a cubic smoothing spline should be used to normalize the data, default = FALSE.}
 
 \item{Sd:}{Numeric, LRR standard deviation for the quantile normarlization, default = 0.18.}
+
+\item{ReCenter:}{Re-center LRR mean to be zero.}
 }
 \value{
 LRR normalized.

--- a/man/StackPlot.Rd
+++ b/man/StackPlot.Rd
@@ -9,7 +9,7 @@
 \usage{
 StackPlot(Pos, IDs, PathRawData, CNVs, Highlight = NULL, SNPList = NULL,
   key = NA, OutFolder = ".", Files = NA, Pattern = "",
-  recursive = TRUE)
+  recursive = FALSE)
 }
 \arguments{
 \item{Pos:}{Position of the loci to plot in the form chr21:1050000-1350000.}
@@ -32,7 +32,7 @@ StackPlot(Pos, IDs, PathRawData, CNVs, Highlight = NULL, SNPList = NULL,
 
 \item{Pattern:}{File pattern in the raw data, default = "*".}
 
-\item{Recursive:}{Logical, Unknown, default = TRUE.}
+\item{Recursive:}{Logical, Should files matching patterns in subfolders be included, default = FALSE.}
 }
 \value{
 A png plot of the specified loci.


### PR DESCRIPTION
Hi there. Sorry @idaElken I did not understand the issue you pointed out in pull request #33 about the position and highlight

"When you define Position of plot and highlight and the start and ending-point of the CNV is outside of the plot, the CNV is not drawn..."

I cannot replicate that behaviour could you try and make an example using mockCNVs, then I would be happy to have a look at it.

Best,
Johan

